### PR TITLE
Nvim 0.9

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -2,7 +2,7 @@ local Plug = vim.fn['plug#']
 
 vim.call('plug#begin', vim.fn.stdpath('data') .. '/plugged')
 
-Plug('nvim-treesitter/nvim-treesitter', {tag = 'v0.9.1', ['do'] = ':TSUpdate'}) -- Syntax highlighting
+Plug('nvim-treesitter/nvim-treesitter', {tag = 'v0.9.3', ['do'] = ':TSUpdate'}) -- Syntax highlighting
 vim.g.tex_flavor = "latex" -- Treat ".tex" files as LaTeX by default
 Plug('mg979/vim-visual-multi') -- Multiple cursors
 Plug('joom/latex-unicoder.vim') -- Ctrl-L converts latex code to actual symbols, as in \alpha -> α
@@ -82,7 +82,7 @@ vim.g.slime_dont_ask_default = 1
 
 -- Fuzzy searching with Telescope
 Plug('nvim-lua/plenary.nvim')
-Plug('nvim-telescope/telescope.nvim', {tag = "0.1.8"})
+Plug('nvim-telescope/telescope.nvim', {tag = "v0.1.9"})
 Plug('nvim-telescope/telescope-fzf-native.nvim', { ['do'] = 'make' })
 Plug('kyazdani42/nvim-web-devicons')
 vim.keymap.set('n', '<C-T>', '<Cmd>lua project_files()<CR>', {}) -- Ctrl-T to pick by file name


### PR DESCRIPTION
## Summary

- Updated nvim-treesitter from `tag = 'v0.9.1'` to `tag = 'v0.9.3'` (last release supporting nvim 0.9; v0.9.4+ requires nvim 0.10)
- Updated telescope.nvim from `tag = "0.1.8"` to `tag = "0.1.9"` (last in the 0.1.x series; 0.2.x requires nvim >= 0.10.4)

No API modernization needed — the deprecations introduced in nvim 0.9 (vim.loop, vim.tbl_flatten, nvim_set_option, etc.) are not used in the config.

## Test plan

- [x] Open nvim and run `:PlugUpdate` — treesitter and telescope update without errors
- [x] Run `:TSUpdate` — parsers install successfully
- [x] Open a code file — treesitter highlighting works, no errors in `:checkhealth nvim-treesitter`
- [x] Run `<C-T>` and `<C-G>` — telescope pickers open correctly